### PR TITLE
Added more guards to ensure that recurring events are not created in the case of non-recurring events.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEventCommandParser.java
@@ -35,15 +35,16 @@ public class AddEventCommandParser implements Parser<AddEventCommand> {
         DateTime startDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_START_DATE_TIME).get());
         DateTime endDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_END_DATE_TIME).get());
 
-        if (argMultimap.getValue(PREFIX_RECURRENCE).isEmpty()) {
-            // Non-recurring event
-            return new AddEventCommand(new OneTimeEvent(desc, startDateTime, endDateTime, new HashSet<>()));
-        } else {
-            // Recurring event
+        if (argMultimap.getValue(PREFIX_RECURRENCE).isPresent()) {
             Recurrence recurrence = ParserUtil.parseRecurrence(argMultimap.getValue(PREFIX_RECURRENCE).get());
-            return new AddEventCommand(new RecurringEvent(desc, startDateTime, endDateTime,
-                    recurrence, new HashSet<>()));
+            if (recurrence.isRecurring()) {
+                // Recurring event
+                return new AddEventCommand(new RecurringEvent(desc, startDateTime, endDateTime,
+                        recurrence, new HashSet<>()));
+            }
         }
+        // Non-recurring event
+        return new AddEventCommand(new OneTimeEvent(desc, startDateTime, endDateTime, new HashSet<>()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -126,12 +126,18 @@ public abstract class Event {
         return taggedPeople.stream().anyMatch(p -> Objects.equals(person, p));
     }
 
+    /**
+     * Returns a copy of the start date time.
+     */
     public DateTime getEffectiveStartDateTime() {
-        return startDateTime;
+        return new DateTime(this.startDateTime.getDateTime());
     }
 
+    /**
+     * Returns a copy of the end date time.
+     */
     public DateTime getEffectiveEndDateTime() {
-        return endDateTime;
+        return new DateTime(this.endDateTime.getDateTime());
     }
 
     /**

--- a/src/main/java/seedu/address/model/event/RecurringEvent.java
+++ b/src/main/java/seedu/address/model/event/RecurringEvent.java
@@ -25,8 +25,14 @@ public class RecurringEvent extends Event {
      */
     @Override
     public DateTime getEffectiveStartDateTime() {
+        if (!this.isRecurring()) {
+            return new DateTime(getStartDateTime().getDateTime());
+        }
+        // Gets the difference between start date time, end date time.
         long minutesElapsed = DateTime.getIntervalDuration(getStartDateTime(), getEndDateTime(), ChronoUnit.MINUTES);
+        // Then calculates the effective end datetime.
         DateTime effectiveEnd = getEffectiveEndDateTime();
+        // Then we get the new start date time by doing end date time minus the difference calculated earlier.
         return new DateTime(effectiveEnd.getDateTime().minusMinutes(minutesElapsed));
     }
 
@@ -36,6 +42,9 @@ public class RecurringEvent extends Event {
     @Override
     public DateTime getEffectiveEndDateTime() {
         LocalDateTime current = getEndDateTime().getDateTime();
+        if (!this.isRecurring()) {
+            return new DateTime(current);
+        }
         while (current.isBefore(LocalDateTime.now())) {
             current = current.plus(1, getRecurrence().getIncrementUnit());
         }


### PR DESCRIPTION
Added a guard to AddEventCommand to fix the bug where:
using
addevent ... r/none
Will create a RecurringEvent with a None Recurrence instead of a OneTimeEvent.

This caused the bug in #249 due to the different implementations for getEffective time methods.


Edit from @hansstanley 
- Closes #249